### PR TITLE
Fix crash while creating or loading invalid SpineResources

### DIFF
--- a/register_types.cpp
+++ b/register_types.cpp
@@ -176,16 +176,16 @@ public:
 			json->scale = 1;
 			
 			res->data = spSkeletonJson_readSkeletonDataFile(json, p_path.utf8().get_data());
-			spSkeletonJson_dispose(json);
 			ERR_EXPLAIN(json->error ? json->error : "");
+			spSkeletonJson_dispose(json);
 			ERR_FAIL_COND_V(res->data == NULL, RES());
 		} else {
 			spSkeletonBinary* bin  = spSkeletonBinary_create(res->atlas);
 			ERR_FAIL_COND_V(bin == NULL, RES());
 			bin->scale = 1;
 			res->data = spSkeletonBinary_readSkeletonDataFile(bin, p_path.utf8().get_data());
-			spSkeletonBinary_dispose(bin);
 			ERR_EXPLAIN(bin->error ? bin->error : "");
+			spSkeletonBinary_dispose(bin);
 			ERR_FAIL_COND_V(res->data == NULL, RES());
 		}
 			

--- a/spine.cpp
+++ b/spine.cpp
@@ -616,7 +616,7 @@ void Spine::set_resource(Ref<Spine::SpineResource> p_data) {
 	_spine_dispose();
 
 	res = p_data;
-	if (res.is_null())
+	if (res.is_null() || !res->data)
 		return;
 
 	skeleton = spSkeleton_create(res->data);


### PR DESCRIPTION
* Fix crash while creating a new SpineResource in the editor inspector
* Fix crash while loading a SpineResource with unknown version